### PR TITLE
add example module

### DIFF
--- a/terraform/aws/module_usage.tf
+++ b/terraform/aws/module_usage.tf
@@ -1,0 +1,7 @@
+module "sg" {
+  source = "./modules/security_group"
+
+  port = 22
+  cidrs = ["0.0.0.0/0"]
+
+}

--- a/terraform/aws/modules/security_group/main.tf
+++ b/terraform/aws/modules/security_group/main.tf
@@ -1,0 +1,26 @@
+
+
+resource "aws_security_group" "sg" {
+  name        = "sg"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = "vpc-123"
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = var.port
+    to_port     = var.port
+    protocol    = "tcp"
+    cidr_blocks = var.cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_ssh"
+  }
+}

--- a/terraform/aws/modules/security_group/variables.tf
+++ b/terraform/aws/modules/security_group/variables.tf
@@ -1,0 +1,7 @@
+variable "port" {
+
+}
+
+variable "cidrs" {
+  
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable configuration for creating AWS security groups that allow inbound traffic on a specified port from defined CIDR blocks.
  * Added the ability to customize allowed ports and CIDR ranges when setting up security groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->